### PR TITLE
Resolve category facet names in search context

### DIFF
--- a/src/components/Facets/SelectedFilters.tsx
+++ b/src/components/Facets/SelectedFilters.tsx
@@ -9,7 +9,7 @@ it.
 
 import { Fragment, FunctionComponent } from 'preact';
 
-import { useProducts, useSearch, useTranslation } from '../../context';
+import { useCategories, useProducts, useSearch, useTranslation } from '../../context';
 import Pill from '../Pill';
 import { formatBinaryLabel, formatRangeLabel } from './format';
 
@@ -21,6 +21,14 @@ export const SelectedFilters: FunctionComponent<SelectedFiltersProps> = ({ direc
   const searchCtx = useSearch();
   const productsCtx = useProducts();
   const translation = useTranslation();
+  const { categories }  = useCategories();
+
+  const additionalCategoryNames = categories?.map(({ name, urlPath }) => ({
+    name,
+    value: urlPath,
+    attribute: 'categories'
+  }));
+  const allCategoryNames = [...searchCtx.categoryNames, ...additionalCategoryNames];
 
   return (
     <div className="w-full">
@@ -33,13 +41,13 @@ export const SelectedFilters: FunctionComponent<SelectedFiltersProps> = ({ direc
                   key={formatBinaryLabel(
                     filter,
                     option,
-                    searchCtx.categoryNames,
+                    allCategoryNames as any,
                     productsCtx.categoryPath
                   )}
                   label={formatBinaryLabel(
                     filter,
                     option,
-                    searchCtx.categoryNames,
+                    allCategoryNames as any,
                     productsCtx.categoryPath
                   )}
                   type="transparent"

--- a/src/components/Facets/format.ts
+++ b/src/components/Facets/format.ts
@@ -39,7 +39,7 @@ const formatBinaryLabel = (
   categoryNames?: { value: string; name: string; attribute: string }[],
   categoryPath?: string
 ) => {
-  if (categoryPath && categoryNames) {
+  if (categoryNames) {
     const category = categoryNames.find(
       (facet) => facet.attribute === filter.attribute && facet.value === option
     );

--- a/src/components/InputButtonGroup/InputButtonGroup.tsx
+++ b/src/components/InputButtonGroup/InputButtonGroup.tsx
@@ -121,9 +121,7 @@ export const InputButtonGroup: FunctionComponent<InputButtonGroupProps> = ({
       }`;
       return label;
     } else if (bucket.__typename === 'CategoryView') {
-      return productsCtx.categoryPath
-        ? bucket.name ?? bucket.title
-        : bucket.title;
+      return bucket.name;
     } else if (bucket.title === BOOLEAN_YES) {
       return title;
     } else if (bucket.title === BOOLEAN_NO) {


### PR DESCRIPTION
* Fixed facet selection to use proper category name for displaying.
* Fixed selected facet component to show proper category name for displaying currently selected facet. 

Fixes https://github.com/hlxsites/sony-biotech/issues/234